### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,10 @@ class MainActivity : AppCompatActivity() {
 
 **Compose:**
 
+In compose for android, the MainActivity is extended from ComponentActivity, we need to change it to FragmentActivity
+
 ```kotlin
-class MainActivity : AppCompatActivity() {
+class MainActivity : FragmentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -175,11 +177,6 @@ Additionally, you need add `NSFaceIDUsageDescription` key in Info.plist of your 
 ```
 
 **Compose Multiplatform:**
-
-Note:
-
-
-In compose for android, the MainActivity is extended from ComponentActivity, we need to change it to FragmentActivity
 
 ```kotlin
 @Composable

--- a/README.md
+++ b/README.md
@@ -176,6 +176,11 @@ Additionally, you need add `NSFaceIDUsageDescription` key in Info.plist of your 
 
 **Compose Multiplatform:**
 
+Note:
+
+
+In compose for android, the MainActivity is extended from ComponentActivity, we need to change it to FragmentActivity
+
 ```kotlin
 @Composable
 fun BiometryScreen() {


### PR DESCRIPTION
Adding instruction to change MainActivity extended from.

The current ComponentActivity will leads app to crash, because of this cast `(context as FragmentActivity)` in [here](https://github.com/icerockdev/moko-biometry/blob/master/biometry-compose/src/androidMain/kotlin/dev/icerock/moko/biometry/compose/BindBiometryAuthenticatorEffect.android.kt).